### PR TITLE
Update libprotobuf to version 3.19.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/archive/v{{ version }}/libprotobuf-v{{ version }}.tar.gz
-    sha256: 87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422
+    sha256: 5dc92703f811f94e2aa63bdab07ab749f28a094befa6cdfd5fe177f947590a48
     patches:
       - 0001-remove-Werror-from-test-flags.patch  # [ppc64le or aarch64 or s390x]
       - 0002-remove-failing-json-parser-test.patch  # [s390x]
@@ -19,10 +19,10 @@ source:
   # these are git submodules from the 3.10.1 release
   # https://github.com/protocolbuffers/protobuf/tree/v3.10.1/third_party
   - url: https://github.com/google/benchmark/archive/5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8.tar.gz
-    sha256: 87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422
+    sha256: 5dc92703f811f94e2aa63bdab07ab749f28a094befa6cdfd5fe177f947590a48
     folder: third_party/benchmark
   - url: https://github.com/google/googletest/archive/5ec7f0c4a113e2f18ac2c6cc7df51ad6afc24081.tar.gz
-    sha256: 87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422
+    sha256: 5dc92703f811f94e2aa63bdab07ab749f28a094befa6cdfd5fe177f947590a48
     folder: third_party/googletest
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.17.2" %}
+{% set version = "3.19.1" %}
 
 package:
   name: libprotobuf-suite
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/archive/v{{ version }}/libprotobuf-v{{ version }}.tar.gz
-    sha256: 36f81e03a0702f8f935fffd5a486dac1c0fc6d4bae1cd02c7a32448ad6e63bcb
+    sha256: 87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422
     patches:
       - 0001-remove-Werror-from-test-flags.patch  # [ppc64le or aarch64 or s390x]
       - 0002-remove-failing-json-parser-test.patch  # [s390x]
@@ -19,10 +19,10 @@ source:
   # these are git submodules from the 3.10.1 release
   # https://github.com/protocolbuffers/protobuf/tree/v3.10.1/third_party
   - url: https://github.com/google/benchmark/archive/5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8.tar.gz
-    sha256: 5dc92703f811f94e2aa63bdab07ab749f28a094befa6cdfd5fe177f947590a48
+    sha256: 87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422
     folder: third_party/benchmark
   - url: https://github.com/google/googletest/archive/5ec7f0c4a113e2f18ac2c6cc7df51ad6afc24081.tar.gz
-    sha256: 0e2f36e8e403c125fd0ab02171bdb786d3b6b3875b6ccf3b2eb7969be8faecd0
+    sha256: 87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422
     folder: third_party/googletest
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ outputs:
         - pkg-config  # [not win]
         - unzip  # [not win]
         - make  # [not win]
+        - patch  # [not win]
       host:
         - zlib
       run:
@@ -106,6 +107,7 @@ about:
     Protocol buffers are Google's language-neutral,
     platform-neutral, extensible mechanism for serializing structured data-
     think XML, but smaller, faster, and simpler.
+  dev_url: https://github.com/protocolbuffers/protobuf
   doc_url: https://developers.google.com/protocol-buffers/
   doc_source_url: https://github.com/protocolbuffers/protobuf/releases
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -79,6 +79,7 @@ outputs:
         - pkg-config  # [not win]
         - unzip  # [not win]
         - make  # [not win]
+        - patch  # [not win]
       host:
         - zlib    # [not win]
         - {{ pin_subpackage('libprotobuf', exact=True) }}  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/archive/v{{ version }}/libprotobuf-v{{ version }}.tar.gz
-    sha256: 5dc92703f811f94e2aa63bdab07ab749f28a094befa6cdfd5fe177f947590a48
+    sha256: 87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422
     patches:
       - 0001-remove-Werror-from-test-flags.patch  # [ppc64le or aarch64 or s390x]
       - 0002-remove-failing-json-parser-test.patch  # [s390x]
@@ -22,7 +22,7 @@ source:
     sha256: 5dc92703f811f94e2aa63bdab07ab749f28a094befa6cdfd5fe177f947590a48
     folder: third_party/benchmark
   - url: https://github.com/google/googletest/archive/5ec7f0c4a113e2f18ac2c6cc7df51ad6afc24081.tar.gz
-    sha256: 5dc92703f811f94e2aa63bdab07ab749f28a094befa6cdfd5fe177f947590a48
+    sha256: 0e2f36e8e403c125fd0ab02171bdb786d3b6b3875b6ccf3b2eb7969be8faecd0
     folder: third_party/googletest
 
 build:


### PR DESCRIPTION
  `libprotobuf` version `3.19.1`
1. check the upstream
    https://github.com/protocolbuffers/protobuf/tree/v3.19.1

2. check the pinnings
    https://github.com/protocolbuffers/protobuf/blob/v3.19.1/protobuf_version.bzl

    https://github.com/protocolbuffers/protobuf/blob/v3.19.1/protobuf_deps.bzl

    https://github.com/protocolbuffers/protobuf/blob/v3.19.1/post_process_dist.sh

    https://github.com/protocolbuffers/protobuf/blob/v3.19.1/appveyor.bat

3. check the changelogs
    https://github.com/protocolbuffers/protobuf/blob/v3.19.1/CHANGES.txt

4. additional research
    https://github.com/conda-forge/libprotobuf-feedstock/issues

    There is one known issue in the upstream for users trying to build the package from source using cmake. In this case we do not seem to have an issue with the package but we should keep an eye on the package. 

5. verify dev_url
    https://github.com/protocolbuffers/protobuf

6. verify doc_url
    https://developers.google.com/protocol-buffers/

7. added the dev_url
8. veriy the test section
9. additional tests

In order to test the `libprotobuf` package version `3.19.1` the folowing
command was used:
`conda build libprotobuf-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that .... to update `libprotobuf` to version `3.19.1`
