### PR TITLE
3.20.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  build: libprotobuf

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  build: libprotobuf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,10 +21,10 @@ source:
   # these are git submodules from the {{ version }} release
   # https://github.com/protocolbuffers/protobuf/tree/v{{ version }}/third_party
   - url: https://github.com/google/benchmark/archive/5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8.tar.gz
-    sha256: 5dc92703f811f94e2aa63bdab07ab749f28a094befa6cdfd5fe177f947590a48
+    sha256: df8c636240df6d0139282dc507e240d04a2893195b7574aa489cc6b6a67fa034
     folder: third_party/benchmark
   - url: https://github.com/google/googletest/archive/5ec7f0c4a113e2f18ac2c6cc7df51ad6afc24081.tar.gz
-    sha256: 0e2f36e8e403c125fd0ab02171bdb786d3b6b3875b6ccf3b2eb7969be8faecd0
+    sha256: 53674b2fd7b4499e2b8019b0943c3a37fa394c86a9ab52bf8910749c0414bb47
     folder: third_party/googletest
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/archive/v{{ version }}/libprotobuf-v{{ version }}.tar.gz
-    sha256: 9c0fd39c7a08dff543c643f0f4baf081988129a411b977a07c46221793605638
+    sha256: a4d420a7b727a183475641c2b372389395101bc06aa00525720039fb3a9d8389
     patches:  # [linux]
       # We don't want the build to fail because of -Werror being used during
       # make check.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.20.1" %}
+{% set version = "3.20.3" %}
 
 package:
   name: libprotobuf-suite
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/archive/v{{ version }}/libprotobuf-v{{ version }}.tar.gz
-    sha256: 8b28fdd45bab62d15db232ec404248901842e5340299a57765e48abe8a80d930
+    sha256: 9c0fd39c7a08dff543c643f0f4baf081988129a411b977a07c46221793605638
     patches:  # [linux]
       # We don't want the build to fail because of -Werror being used during
       # make check.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -118,7 +118,6 @@ about:
     think XML, but smaller, faster, and simpler.
   dev_url: https://github.com/protocolbuffers/protobuf
   doc_url: https://developers.google.com/protocol-buffers/
-  doc_source_url: https://github.com/protocolbuffers/protobuf/releases
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/archive/v{{ version }}/libprotobuf-v{{ version }}.tar.gz
-    sha256: a4d420a7b727a183475641c2b372389395101bc06aa00525720039fb3a9d8389
+    sha256: 9c0fd39c7a08dff543c643f0f4baf081988129a411b977a07c46221793605638
     patches:  # [linux]
       # We don't want the build to fail because of -Werror being used during
       # make check.
@@ -21,10 +21,10 @@ source:
   # these are git submodules from the {{ version }} release
   # https://github.com/protocolbuffers/protobuf/tree/v{{ version }}/third_party
   - url: https://github.com/google/benchmark/archive/5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8.tar.gz
-    sha256: df8c636240df6d0139282dc507e240d04a2893195b7574aa489cc6b6a67fa034
+    sha256: 5dc92703f811f94e2aa63bdab07ab749f28a094befa6cdfd5fe177f947590a48
     folder: third_party/benchmark
   - url: https://github.com/google/googletest/archive/5ec7f0c4a113e2f18ac2c6cc7df51ad6afc24081.tar.gz
-    sha256: 53674b2fd7b4499e2b8019b0943c3a37fa394c86a9ab52bf8910749c0414bb47
+    sha256: 0e2f36e8e403c125fd0ab02171bdb786d3b6b3875b6ccf3b2eb7969be8faecd0
     folder: third_party/googletest
 
 build:


### PR DESCRIPTION
# libprotobuf 3.20.3

jira: https://anaconda.atlassian.net/browse/PKG-689
upstream: https://github.com/protocolbuffers/protobuf/tree/v3.20.3
diff: https://github.com/protocolbuffers/protobuf/compare/v3.20.1...v3.20.3
license: https://github.com/protocolbuffers/protobuf/blob/v3.20.3/LICENSE

## Changes
- Update version and SHA

## Notes
- This fixes two CVEs: CVE-2022-3171 and CVE-2022-1941
- Needs to be deployed before https://github.com/AnacondaRecipes/protobuf-feedstock/pull/18
- After deploying: https://github.com/AnacondaRecipes/aggregate/pull/247 needs applied

## Related PRs
- https://github.com/AnacondaRecipes/protobuf-feedstock/pull/18
- https://github.com/AnacondaRecipes/grpc-cpp-feedstock/pull/19
- https://github.com/AnacondaRecipes/onnx-feedstock/pull/7
- https://github.com/AnacondaRecipes/aggregate/pull/247
- https://github.com/AnacondaRecipes/libprotobuf-feedstock/pull/20
