### PR TITLE
3.19.6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  build: libprotobuf

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  build: libprotobuf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -110,7 +110,6 @@ about:
     think XML, but smaller, faster, and simpler.
   dev_url: https://github.com/protocolbuffers/protobuf
   doc_url: https://developers.google.com/protocol-buffers/
-  doc_source_url: https://github.com/protocolbuffers/protobuf/releases
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.19.4" %}
+{% set version = "3.19.6" %}
 
 package:
   name: libprotobuf-suite
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/archive/v{{ version }}/libprotobuf-v{{ version }}.tar.gz
-    sha256: 3bd7828aa5af4b13b99c191e8b1e884ebfa9ad371b0ce264605d347f135d2568
+    sha256: 6ee46b428fd080150d6c48335bc89a5296820df709b27678ce522dc27d211329
     patches:
       - 0001-remove-Werror-from-test-flags.patch  # [ppc64le or aarch64 or s390x]
       # - 0002-remove-failing-json-parser-test.patch  # [s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,7 +81,7 @@ outputs:
         - pkg-config  # [not win]
         - unzip  # [not win]
         - make  # [not win]
-        - patch  # [not win]
+        - patch # [ppc64le or aarch64 or s390x]
       host:
         - zlib    # [not win]
         - {{ pin_subpackage('libprotobuf', exact=True) }}  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,10 +19,10 @@ source:
   # these are git submodules from the 3.10.1 release
   # https://github.com/protocolbuffers/protobuf/tree/v3.10.1/third_party
   - url: https://github.com/google/benchmark/archive/5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8.tar.gz
-    sha256: df8c636240df6d0139282dc507e240d04a2893195b7574aa489cc6b6a67fa034
+    sha256: 5dc92703f811f94e2aa63bdab07ab749f28a094befa6cdfd5fe177f947590a48
     folder: third_party/benchmark
   - url: https://github.com/google/googletest/archive/5ec7f0c4a113e2f18ac2c6cc7df51ad6afc24081.tar.gz
-    sha256: 53674b2fd7b4499e2b8019b0943c3a37fa394c86a9ab52bf8910749c0414bb47
+    sha256: 0e2f36e8e403c125fd0ab02171bdb786d3b6b3875b6ccf3b2eb7969be8faecd0
     folder: third_party/googletest
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/archive/v{{ version }}/libprotobuf-v{{ version }}.tar.gz
-    sha256: 6ee46b428fd080150d6c48335bc89a5296820df709b27678ce522dc27d211329
+    sha256: 9a301cf94a8ddcb380b901e7aac852780b826595075577bb967004050c835056
     patches:
       - 0001-remove-Werror-from-test-flags.patch  # [ppc64le or aarch64 or s390x]
       # - 0002-remove-failing-json-parser-test.patch  # [s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,8 @@ outputs:
     script: build-shared.sh  # [unix]
     script: bld-shared.bat  # [win]
     build:
+      missing_dso_whitelist:  # [s390x]
+        - $RPATH/ld64.so.1    # [s390x]
       run_exports:
         # breaks backwards compatibility and new SONAME each minor release
         # https://abi-laboratory.pro/tracker/timeline/protobuf/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ outputs:
         - pkg-config  # [not win]
         - unzip  # [not win]
         - make  # [not win]
-        - patch  # [not win]
+        - patch  # [ppc64le or aarch64 or s390x]
       host:
         - zlib
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.19.1" %}
+{% set version = "3.19.4" %}
 
 package:
   name: libprotobuf-suite
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/archive/v{{ version }}/libprotobuf-v{{ version }}.tar.gz
-    sha256: 87407cd28e7a9c95d9f61a098a53cf031109d451a7763e7dd1253abf8b4df422
+    sha256: 3bd7828aa5af4b13b99c191e8b1e884ebfa9ad371b0ce264605d347f135d2568
     patches:
       - 0001-remove-Werror-from-test-flags.patch  # [ppc64le or aarch64 or s390x]
       - 0002-remove-failing-json-parser-test.patch  # [s390x]
@@ -19,10 +19,10 @@ source:
   # these are git submodules from the 3.10.1 release
   # https://github.com/protocolbuffers/protobuf/tree/v3.10.1/third_party
   - url: https://github.com/google/benchmark/archive/5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8.tar.gz
-    sha256: 5dc92703f811f94e2aa63bdab07ab749f28a094befa6cdfd5fe177f947590a48
+    sha256: df8c636240df6d0139282dc507e240d04a2893195b7574aa489cc6b6a67fa034
     folder: third_party/benchmark
   - url: https://github.com/google/googletest/archive/5ec7f0c4a113e2f18ac2c6cc7df51ad6afc24081.tar.gz
-    sha256: 0e2f36e8e403c125fd0ab02171bdb786d3b6b3875b6ccf3b2eb7969be8faecd0
+    sha256: 53674b2fd7b4499e2b8019b0943c3a37fa394c86a9ab52bf8910749c0414bb47
     folder: third_party/googletest
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
     sha256: 3bd7828aa5af4b13b99c191e8b1e884ebfa9ad371b0ce264605d347f135d2568
     patches:
       - 0001-remove-Werror-from-test-flags.patch  # [ppc64le or aarch64 or s390x]
-      - 0002-remove-failing-json-parser-test.patch  # [s390x]
+      # - 0002-remove-failing-json-parser-test.patch  # [s390x]
       # our build machine does not have enough memory for this test.
       # see: https://github.com/protocolbuffers/protobuf/issues/8082
       # - 0003-remove-large-output-test.patch         # [s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
     folder: third_party/googletest
 
 build:
-  number: 1
+  number: 0
 
 outputs:
   - name: libprotobuf


### PR DESCRIPTION
# libprotobuf 3.19.6

jira: https://anaconda.atlassian.net/browse/PKG-689
upstream: https://github.com/protocolbuffers/protobuf/tree/v3.20.3
diff: https://github.com/protocolbuffers/protobuf/compare/v3.20.1...v3.20.3
license: https://github.com/protocolbuffers/protobuf/blob/v3.20.3/LICENSE

## Changes
- Update version and SHA

## Notes
- This fixes two CVEs: CVE-2022-3171 and CVE-2022-1941
- Needs to be delpoyed before https://github.com/AnacondaRecipes/protobuf-feedstock/pull/19

## Related PRs
- https://github.com/AnacondaRecipes/protobuf-feedstock/pull/18
