### PR TITLE
Update version to 6.33.5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/preprod-pbp/fs/abseil-cpp-feedstock/pr17/4974e53

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/preprod-pbp/fs/abseil-cpp-feedstock/pr17/4974e53

--- a/recipe/build-lib.bat
+++ b/recipe/build-lib.bat
@@ -2,10 +2,12 @@
 
 if "%PKG_NAME%"=="libprotobuf-static" (
     set CF_SHARED=OFF
+    set CF_TESTS=OFF
     mkdir build-static
     cd build-static
 ) else (
     set CF_SHARED=ON
+    set CF_TESTS=ON
     mkdir build-shared
     cd build-shared
 )
@@ -17,7 +19,9 @@ cmake -G "Ninja" ^
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
     -Dprotobuf_ABSL_PROVIDER="package" ^
+    -Dprotobuf_BUILD_LIBUPB=ON ^
     -Dprotobuf_BUILD_SHARED_LIBS=%CF_SHARED% ^
+    -Dprotobuf_BUILD_TESTS=%CF_TESTS% ^
     -Dprotobuf_JSONCPP_PROVIDER="package" ^
     -Dprotobuf_MSVC_STATIC_RUNTIME=OFF ^
     -Dprotobuf_USE_EXTERNAL_GTEST=ON ^
@@ -28,8 +32,10 @@ if %ERRORLEVEL% neq 0 exit 1
 cmake --build .
 if %ERRORLEVEL% neq 0 exit 1
 
-ctest --progress --output-on-failure
-if %ERRORLEVEL% neq 0 exit 1
+if "%PKG_NAME%"=="libprotobuf" (
+    ctest --progress --output-on-failure
+    if %ERRORLEVEL% neq 0 exit 1
+)
 
 cmake --install .
 if %ERRORLEVEL% neq 0 exit 1

--- a/recipe/build-lib.sh
+++ b/recipe/build-lib.sh
@@ -10,8 +10,6 @@ if [[ "$(uname)" == "Linux" ]]; then
     # to improve performance, disable checks intended for debugging
     CXXFLAGS="$CXXFLAGS -DNDEBUG"
 elif [[ "$(uname)" == "Darwin" ]]; then
-    # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
-    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
     # remove pie from LDFLAGS
     LDFLAGS="${LDFLAGS//-pie/}"
     # CoreFoundation is needed as least as of libprotobuf>=4.23.X

--- a/recipe/build-lib.sh
+++ b/recipe/build-lib.sh
@@ -10,14 +10,17 @@ if [[ "$(uname)" == "Linux" ]]; then
     # to improve performance, disable checks intended for debugging
     CXXFLAGS="$CXXFLAGS -DNDEBUG"
 elif [[ "$(uname)" == "Darwin" ]]; then
+    # See https://conda-forge.org/docs/maintainer/knowledge_base.html#newer-c-features-with-old-sdk
+    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
     # remove pie from LDFLAGS
     LDFLAGS="${LDFLAGS//-pie/}"
     # CoreFoundation is needed as least as of libprotobuf>=4.23.X
     LDFLAGS="${LDFLAGS} -framework CoreFoundation"
 fi
 
-# required to pick up conda installed zlib
-export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
+# required to pick up conda installed zlib; ensure UPB symbols are visible, see
+# https://github.com/protocolbuffers/protobuf/blob/v29.1/upb/port/def.inc#L69-L91
+export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include -DUPB_BUILD_API"
 export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 
 # delete vendored gtest to force protobuf_USE_EXTERNAL_GTEST to work;
@@ -26,16 +29,18 @@ rm -rf ./third_party/googletest | true
 
 if [[ "$PKG_NAME" == "libprotobuf-static" ]]; then
     export CF_SHARED=OFF
+    export CF_TESTS=OFF
     mkdir build-static
     cd build-static
 else
     export CF_SHARED=ON
+    export CF_TESTS=ON
     mkdir build-shared
     cd build-shared
-fi
 
-if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 ]]; then
-    export CMAKE_ARGS="${CMAKE_ARGS} -Dprotobuf_BUILD_TESTS=OFF"
+    if [[ "$CONDA_BUILD_CROSS_COMPILATION" == 1 ]]; then
+        export CF_TESTS=OFF
+    fi
 fi
 
 cmake -G "Ninja" \
@@ -43,7 +48,9 @@ cmake -G "Ninja" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_CXX_STANDARD=17 \
     -Dprotobuf_ABSL_PROVIDER="package" \
+    -Dprotobuf_BUILD_LIBUPB=ON \
     -Dprotobuf_BUILD_SHARED_LIBS=$CF_SHARED \
+    -Dprotobuf_BUILD_TESTS=$CF_TESTS \
     -Dprotobuf_JSONCPP_PROVIDER="package" \
     -Dprotobuf_USE_EXTERNAL_GTEST=ON \
     -Dprotobuf_WITH_ZLIB=ON \
@@ -51,7 +58,7 @@ cmake -G "Ninja" \
 
 cmake --build .
 
-if [[ "$CONDA_BUILD_CROSS_COMPILATION" != 1 ]]; then
+if [[ "$CF_TESTS" == "ON" ]]; then
     ctest --progress --output-on-failure
 fi
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
-libabseil: 20250814.1
+libabseil: 20260107.0
 
 # google has moved the lower bound for MSVC to v2022 already in April 2024, see
 # https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 # keep this without major version to let the bot pick it up
-{% set version = "33.0" %}
+{% set version = "33.5" %}
 # protobuf doesn't add the major version in the tag, it's defined per language in
 # https://github.com/protocolbuffers/protobuf/blob/main/version.json
 {% set major = "6" %}
@@ -15,7 +15,7 @@ package:
 
 source:
   - url: https://github.com/protocolbuffers/protobuf/archive/refs/tags/v{{ version.replace(".rc", "-rc") }}.tar.gz
-    sha256: b6b03fbaa3a90f3d4f2a3fa4ecc41d7cd0326f92fcc920a7843f12206c8d52cd
+    sha256: 440848dffa209beb8a04e41cc352762e44f8e91342b2a43aab6af9b30713c2f6
     patches:
       - patches/0001-set-static-lib-extension-on-windows.patch
       - patches/0002-always-look-for-shared-abseil-builds.patch
@@ -34,7 +34,7 @@ source:
       - patches/0008-fix-macos-tls-linking.patch  # [osx]
 
 build:
-  number: 1
+  number: 0
  
 outputs:
   - name: libprotobuf


### PR DESCRIPTION
libprotobuf 6.33.5

**Destination channel:**  defaults

### Links

- [PKG-12367](https://anaconda.atlassian.net/browse/PKG-12367) 
- [Upstream repository](https://github.com/protocolbuffers/protobuf/tree/v33.5)

### Explanation of changes:

- New version number
- Update libabseil
- Update build-lib script


[PKG-12367]: https://anaconda.atlassian.net/browse/PKG-12367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ